### PR TITLE
Removed old command for calibration in OCR example

### DIFF
--- a/examples/ocr/run.sh
+++ b/examples/ocr/run.sh
@@ -13,6 +13,3 @@ env SBT_OPTS="-Xmx4g" sbt "run -c examples/ocr/application.conf"
 cd $ROOT_PATH/examples/ocr/
 ROOT_PATH=`pwd`
 python feature-analysis.py
-
-python ../tools/cali.py ../../target/calibration/label1.val.tsv output/calibration-label1.png
-python ../tools/cali.py ../../target/calibration/label2.val.tsv output/calibration-label2.png


### PR DESCRIPTION
Removed 2 lines for calibration in OCR example.
